### PR TITLE
Add CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: node_js
+node_js:
+  - "node"
+  - "6"
+  - "5"
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # panda-template
 
+[![Build Status](https://travis-ci.org/pandastrike/panda-template.svg)](https://travis-ci.org/pandastrike/panda-template)
+
 Handlebars + Swag + Panda Goodies in a quick and easy interface.
 
 ```coffee


### PR DESCRIPTION
Solves #2 

Do we need to run the tests against any other version of Node? Right now I have it running against the latest stable version, latest v6, latest v5, and latest v4. The only bummer about doing that is it makes CI take a little longer. Since this is OSS my suggestion is we leave it and just deal with longer test cycles. Other opinions?

I currently have email notifications turned off, but would eventually like to create a `#panda-ci` channel in IRC and have it post updates there. (SEE: https://docs.travis-ci.com/user/notifications/#IRC-notification)