### PR TITLE
Bug fix: Avoid Dropping the index.js File During Publish

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "panda-template",
-  "version": "0.4.0",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "name": "panda-template",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Handlebars + Swag + Panda Goodies in a quick and easy interface",
   "main": "./lib/index.js",
   "files": [
-    "lib",
+    "lib/",
     "LICENSE"
   ],
   "scripts": {
     "test": "coffee --transpile test/index.coffee",
-    "prepare": "coffee --transpile --compile --output lib/ src/*.*coffee",
+    "prepare": "node_modules/.bin/coffee --compile --transpile --inline-map --output lib/ src/",
     "watch": "coffee -o lib/ -cw src/*.*coffee",
     "postpublish": "(node_modules/.bin/json -f package.json version | xargs -I version git tag -am version version) && git push --tags"
   },


### PR DESCRIPTION
Now using more care when I publish this to make sure the index file is included.